### PR TITLE
add raw token parsing function

### DIFF
--- a/vmidentity/goclients/oidc/oidcclient.go
+++ b/vmidentity/goclients/oidc/oidcclient.go
@@ -3,8 +3,9 @@ package oidc
 import (
 	"crypto/rsa"
 	"crypto/x509"
-	"gopkg.in/square/go-jose.v2"
 	"time"
+
+	jose "gopkg.in/square/go-jose.v2"
 )
 
 // Client represents an oidc client
@@ -71,6 +72,12 @@ func ParseAndValidateIDTokenMulti(
 // ** This api is exposed temporarily, for a short transition period **
 func ParseTenantInToken(token string) (string, error) {
 	return parseTenantInToken(token)
+}
+
+// ParseSignedToken parses a token string and returns an unvalidated JWT.
+func ParseSignedToken(token string) (JWT, error) {
+	jwt, err := parseSignedToken(token, nil)
+	return jwt, err
 }
 
 // Tokens represents successful acquire token response

--- a/vmidentity/goclients/oidc/token_test.go
+++ b/vmidentity/goclients/oidc/token_test.go
@@ -1,10 +1,11 @@
 package oidc
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateExpiration(t *testing.T) {
@@ -61,13 +62,13 @@ func TestValidateAudienceClaim(t *testing.T) {
 
 func TestParseSignedToken(t *testing.T) {
 	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoic3ViSjEiLCJuYmYiOjE1MjE3NzMwOTgsImV4cCI6MTUyMTc3NjY5OCwiaWF0IjoxNTIxNzczMDk4LCJqdGkiOiJpZDEyMzQ1NiJ9.wf8E82CGm_saE8gGnoz7aX1COSzkc5ZbcO2H7xJSgIQ"
-	jwt, err := parseSignedToken(token, "issuer1", nil, defaultClockToleranceSecs)
+	jwt, err := parseAndValidateSignedToken(token, "issuer1", nil, defaultClockToleranceSecs)
 	assert.Nil(t, jwt, "Token should be nil")
 	if assert.NotNil(t, err, "Error is expected when using unsupported signature algo") {
 		assert.Contains(t, err.Error(), OIDCTokenInvalidError.Name())
 	}
 
-	jwt, err = parseSignedToken("", "issuer1", nil, defaultClockToleranceSecs)
+	jwt, err = parseAndValidateSignedToken("", "issuer1", nil, defaultClockToleranceSecs)
 	assert.Nil(t, jwt, "Token should be nil")
 	if assert.NotNil(t, err, "Error is expected when using bad token") {
 		assert.Contains(t, err.Error(), OIDCTokenInvalidError.Name())
@@ -85,21 +86,21 @@ func TestParseSignedToken(t *testing.T) {
 	require.True(t, ok, "Error when getting keyset from IssuerSigners")
 	require.NotNil(t, s, "KeySet is nil")
 
-	jwt, err = parseSignedToken(strTok, client.Issuer(), s.signers, defaultClockToleranceSecs)
+	jwt, err = parseAndValidateSignedToken(strTok, client.Issuer(), s.signers, defaultClockToleranceSecs)
 	assert.Nil(t, err, "No error expected: %+v", err)
 	assert.NotNil(t, jwt, "Token should not be nil")
 
-	jwt, err = parseSignedToken("  "+strTok+" ", client.Issuer(), s.signers, defaultClockToleranceSecs)
+	jwt, err = parseAndValidateSignedToken("  "+strTok+" ", client.Issuer(), s.signers, defaultClockToleranceSecs)
 	assert.Nil(t, err, "No error expected: %+v", err)
 	assert.NotNil(t, jwt, "Token should not be nil")
 
-	jwt, err = parseSignedToken(strTok+"a", client.Issuer(), s.signers, defaultClockToleranceSecs)
+	jwt, err = parseAndValidateSignedToken(strTok+"a", client.Issuer(), s.signers, defaultClockToleranceSecs)
 	if assert.NotNil(t, err, "Error expected when parsing malformed token") {
 		assert.Contains(t, err.Error(), OIDCTokenInvalidSignatureError.Name(), "Wrong Error code: %+v", err)
 	}
 	assert.Nil(t, jwt, "No token expected")
 
-	jwt, err = parseSignedToken(strTok, "wrongIssuer", s.signers, defaultClockToleranceSecs)
+	jwt, err = parseAndValidateSignedToken(strTok, "wrongIssuer", s.signers, defaultClockToleranceSecs)
 	if assert.NotNil(t, err, "Error expected when token from incorrect issuer") {
 		assert.Contains(t, err.Error(), OIDCTokenInvalidError.Name(), "Wrong Error code: %+v", err)
 	}
@@ -147,7 +148,7 @@ func TestParseHotkClaim(t *testing.T) {
 func testInvalidTokens(t *testing.T, token string) {
 	testInvalidTenantInToken(t, token)
 
-	jwt, err := parseSignedToken(token, "issuer1", nil, defaultClockToleranceSecs)
+	jwt, err := parseAndValidateSignedToken(token, "issuer1", nil, defaultClockToleranceSecs)
 	assert.Nil(t, jwt, "Token should be nil")
 	if assert.NotNil(t, err, "Error is expected when using bad token") {
 		assert.Contains(t, err.Error(), OIDCTokenInvalidError.Name())


### PR DESCRIPTION
* this adds functionality which was present in the c-go client
* JWT is now a public type

TODO: unsure how to run the tests as a cert and config are required.